### PR TITLE
FileSaver.js Fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/FileSaver.js"]
-	path = libs/FileSaver.js
-	url = https://github.com/eligrey/FileSaver.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ function reportWebPackErrors(err, stats) {
 	}));
 }
 
-gulp.task('test', ['prepareTestEnv'], function (cb) {
+gulp.task('test', ['prepareTestEnv'], function () {
 	return gulp.src(['test-env/tests/**/*.js'])
 		.pipe(mocha({
 			debugBrk: DEBUG,

--- a/package.json
+++ b/package.json
@@ -7,29 +7,30 @@
     "test": "tests"
   },
   "dependencies": {
-    "pdfkit": "^0.8.3",
     "iconv-lite": "^0.4.19",
-    "linebreak": "^0.3.0"
+    "linebreak": "^0.3.0",
+    "pdfkit": "^0.8.3"
   },
   "devDependencies": {
+    "brfs": "^1.4.3",
     "expose-loader": "^0.7.3",
+    "file-saver": "^1.3.3",
     "gulp": "^3.9.1",
+    "gulp-each": "^0.5.0",
     "gulp-eslint": "^4.0.0",
+    "gulp-file-contents-to-json": "^0.2.1",
+    "gulp-header": "^1.8.9",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.6.1",
     "gulp-sourcemaps": "^2.6.1",
     "gulp-spawn-mocha": "^4.0.1",
     "gulp-uglify": "^2.1.2",
     "gulp-util": "^3.0.8",
-    "gulp-each": "^0.5.0",
-    "gulp-file-contents-to-json": "^0.2.1",
-    "gulp-header": "^1.8.9",
     "json-loader": "^0.5.7",
-    "sinon": "^4.1.2",
     "mocha": "^4.0.1",
+    "sinon": "^4.1.2",
     "string-replace-webpack-plugin": "^0.1.3",
     "transform-loader": "^0.2.4",
-    "brfs": "^1.4.3",
     "webpack": "^3.9.1",
     "webpack-stream": "^3.2.0"
   },

--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -2,7 +2,7 @@
 
 var PdfPrinter = require('../printer');
 var isFunction = require('../helpers').isFunction;
-var FileSaver = require('../../libs/FileSaver.js/FileSaver');
+var FileSaver = require('file-saver');
 var saveAs = FileSaver.saveAs;
 
 var defaultClientFonts = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 		loaders: [
 			{test: /\.json$/, loader: 'json-loader'},
 			{test: /pdfMake.js$/, loader: 'expose?pdfMake', include: [path.join(__dirname, './src/browser-extensions')]},
-			{test: /pdfkit[\/\\]js[\/\\]mixins[\/\\]fonts.js$/, loader: StringReplacePlugin.replace({
+			{test: /pdfkit[/\\]js[/\\]mixins[/\\]fonts.js$/, loader: StringReplacePlugin.replace({
 					replacements: [
 						{
 							pattern: 'return this.font(\'Helvetica\');',
@@ -28,7 +28,7 @@ module.exports = {
 						}
 					]})
 			},
-			{test: /fontkit[\/\\]index.js$/, loader: StringReplacePlugin.replace({
+			{test: /fontkit[/\\]index.js$/, loader: StringReplacePlugin.replace({
 					replacements: [
 						{
 							pattern: /fs\./g,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,9 +49,9 @@ module.exports = {
 						}
 					]})
 			},
-			{enforce: 'post', test: /fontkit[\/\\]index.js$/, loader: "transform?brfs"},
-			{enforce: 'post', test: /unicode-properties[\/\\]index.js$/, loader: "transform?brfs"},
-			{enforce: 'post', test: /linebreak[\/\\]src[\/\\]linebreaker.js/, loader: "transform?brfs"}
+			{enforce: 'post', test: /fontkit[/\\]index.js$/, loader: "transform?brfs"},
+			{enforce: 'post', test: /unicode-properties[/\\]index.js$/, loader: "transform?brfs"},
+			{enforce: 'post', test: /linebreak[/\\]src[/\\]linebreaker.js/, loader: "transform?brfs"}
 		]
 	},
 	plugins: [


### PR DESCRIPTION
I've got a problem with [file-saver](https://github.com/eligrey/FileSaver.js) third-party library. Unfortunately it doesn't clone at all with whole repo. So I decided to add this library as `devDependencies` in `package.json`. I think this approach is more appropriate in this instance.

Fixes list:
- Install [file-saver](https://github.com/eligrey/FileSaver.js)
- Replace `var FileSaver = require('../../libs/FileSaver.js/FileSaver');` -> `var FileSaver = require('file-saver');` for more info, please follow [this link](http://take.ms/iRVZB)
- Sorted `package.json`
- Fix some typos